### PR TITLE
feature/DVOP-2410

### DIFF
--- a/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -1,8 +1,3 @@
 runcmd:
-  - wait
-  - cp /opt/jfrog/artifactory/var/etc/artifactory/test.txt /opt/jfrog/artifactory/var/etc/artifactory/test2.txt
-  - wait
   - systemctl enable artifactory
-  - wait
   - systemctl restart artifactory
-  - wait

--- a/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -2,3 +2,7 @@ runcmd:
   - systemctl enable artifactory
   - wait
   - systemctl restart artifactory
+  - wait
+  - cp /opt/jfrog/artifactory/var/etc/artifactory/test.txt /opt/jfrog/artifactory/var/etc/artifactory/test2.txt
+  - wait
+  - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -1,7 +1,3 @@
 runcmd:
-  - cat <<EOF > /opt/jfrog/artifactory/var/etc/artifactory/test.txt
-    ${artifactory_license}
-    EOF
-  - wait  
   - systemctl enable artifactory
   - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -1,3 +1,7 @@
 runcmd:
+  - cat <<EOF > /opt/jfrog/artifactory/var/etc/artifactory/test.txt
+    ${artifactory_license}
+    EOF
+  - wait  
   - systemctl enable artifactory
   - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -1,3 +1,0 @@
-runcmd:
-  - systemctl enable artifactory
-  - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -1,3 +1,4 @@
 runcmd:
   - systemctl enable artifactory
+  - wait
   - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/instance/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -1,8 +1,8 @@
 runcmd:
+  - wait
+  - cp /opt/jfrog/artifactory/var/etc/artifactory/test.txt /opt/jfrog/artifactory/var/etc/artifactory/test2.txt
+  - wait
   - systemctl enable artifactory
   - wait
   - systemctl restart artifactory
   - wait
-  - cp /opt/jfrog/artifactory/var/etc/artifactory/test.txt /opt/jfrog/artifactory/var/etc/artifactory/test2.txt
-  - wait
-  - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -806,3 +806,4 @@ write_files:
     permissions: '0644'
     content: |
       test 
+      ${artifactory_access_token}

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -801,8 +801,3 @@ write_files:
           </authentication>
       </config>
 
-  - path: /opt/jfrog/artifactory/var/etc/artifactory/artifactory.lic
-    owner: artifactory:artifactory
-    permissions: '0644'
-    content: |
-      ${artifactory_license}

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -802,7 +802,8 @@ write_files:
   - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
     permissions: '0644'
     content: |
-      ${artifactory_license}
+      TEST
+      ${artifactory_access_token}
 
 runcmd:
   - systemctl enable artifactory 
@@ -811,4 +812,9 @@ runcmd:
   - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/artifactory.config.import.xml
   - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/test.txt
   - wait
+  - cat <<EOF > /opt/jfrog/artifactory/var/etc/artifactory/test2.txt
+test again via eof cmd run
+EOF
+  - wait
+  - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/test2.txt
   - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -805,4 +805,4 @@ write_files:
     owner: artifactory:artifactory
     permissions: '0644'
     content: |
-      test
+      ${artifactory_license}

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -802,14 +802,9 @@ write_files:
   - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
     permissions: '0644'
     content: |
-      TEST
-      ${artifactory_access_token}
+      ${artifactory_license}
 
 runcmd:
   - systemctl enable artifactory 
-  - wait
-  - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/system.yaml
-  - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/artifactory.config.import.xml
-  - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/test.txt
   - wait
   - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -802,7 +802,8 @@ write_files:
   - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
     permissions: '0644'
     content: |
-      ${artifactory_license}
+      TEST
+      ${artifactory_access_token}
 
 runcmd:
   - systemctl enable artifactory 

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -801,8 +801,8 @@ write_files:
           </authentication>
       </config>
 
-path: /opt/jfrog/artifactory/var/etc/artifactory/artifactory.lic
+  - path: /opt/jfrog/artifactory/var/etc/artifactory/artifactory.lic
     owner: artifactory:artifactory
     permissions: '0644'
     content: |
-    ${artifactory_license}
+      ${artifactory_license}

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -806,5 +806,4 @@ write_files:
 
 runcmd:
   - systemctl enable artifactory 
-  - wait
   - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -799,7 +799,7 @@ write_files:
           </authentication>
       </config>
 
-  - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
+  - path: /opt/jfrog/artifactory/var/etc/artifactory/artifactory.lic
     permissions: '0644'
     content: |
       ${artifactory_license}

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -805,5 +805,4 @@ write_files:
     owner: artifactory:artifactory
     permissions: '0644'
     content: |
-      test 
-      ${artifactory_access_token}
+      ${artifactory_license}

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -800,3 +800,9 @@ write_files:
               <tokens/>
           </authentication>
       </config>
+
+path: /opt/jfrog/artifactory/var/etc/artifactory/artifactory.lic
+    owner: artifactory:artifactory
+    permissions: '0644'
+    content: |
+    ${artifactory_license}

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -812,9 +812,4 @@ runcmd:
   - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/artifactory.config.import.xml
   - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/test.txt
   - wait
-  - cat <<EOF > /opt/jfrog/artifactory/var/etc/artifactory/test2.txt
-test again via eof cmd run
-EOF
-  - wait
-  - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/test2.txt
   - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -1,6 +1,5 @@
 write_files:
   - path: /opt/jfrog/artifactory/var/etc/system.yaml
-    owner: artifactory:artifactory
     permissions: '0644'
     content: |
       ## @formatter:off
@@ -61,7 +60,6 @@ write_files:
       password: ${db_password}    
 
   - path: /opt/jfrog/artifactory/var/etc/artifactory/artifactory.config.import.xml
-    owner: artifactory:artifactory
     permissions: '0644'
     content: |
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -800,3 +798,18 @@ write_files:
               <tokens/>
           </authentication>
       </config>
+
+  - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
+    permissions: '0644'
+    content: |
+      TEST
+      ${artifactory_access_token}
+
+runcmd:
+  - systemctl enable artifactory 
+  - wait
+  - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/system.yaml
+  - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/artifactory.config.import.xml
+  - chmod artifactory:artifactory /opt/jfrog/artifactory/var/etc/artifactory/test.txt
+  - wait
+  - systemctl restart artifactory

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -800,9 +800,3 @@ write_files:
               <tokens/>
           </authentication>
       </config>
-
-  - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
-    owner: artifactory:artifactory
-    permissions: '0644'
-    content: |
-      ${artifactory_license}

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -800,3 +800,9 @@ write_files:
               <tokens/>
           </authentication>
       </config>
+
+  - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
+    owner: artifactory:artifactory
+    permissions: '0644'
+    content: |
+      test

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -802,8 +802,7 @@ write_files:
   - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
     permissions: '0644'
     content: |
-      TEST
-      ${artifactory_access_token}
+      ${artifactory_license}
 
 runcmd:
   - systemctl enable artifactory 

--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -801,3 +801,8 @@ write_files:
           </authentication>
       </config>
 
+  - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
+    owner: artifactory:artifactory
+    permissions: '0644'
+    content: |
+      test 

--- a/groups/instance/cloud-init/templates/enable_license.tpl
+++ b/groups/instance/cloud-init/templates/enable_license.tpl
@@ -1,7 +1,0 @@
-write_files:
-  - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
-    owner: artifactory:artifactory
-    permissions: '0644'
-    content: |
-      test
-      ${artifactory_access_token}

--- a/groups/instance/cloud-init/templates/enable_license.tpl
+++ b/groups/instance/cloud-init/templates/enable_license.tpl
@@ -1,0 +1,6 @@
+write_files:
+  - path: /opt/jfrog/artifactory/var/etc/artifactory/test.txt
+    owner: artifactory:artifactory
+    permissions: '0644'
+    content: |
+      test2

--- a/groups/instance/cloud-init/templates/enable_license.tpl
+++ b/groups/instance/cloud-init/templates/enable_license.tpl
@@ -3,4 +3,5 @@ write_files:
     owner: artifactory:artifactory
     permissions: '0644'
     content: |
-      test2
+      test
+      ${artifactory_access_token}

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -38,13 +38,6 @@ data "cloudinit_config" "artifactory" {
       db_username                                = local.db_username
       db_password                                = local.db_password
       artifactory_license                        = local.artifactory_license
-      artifactory_access_token                   = local.artifactory_access_token
     })
   }
-
-  #part {
-  #  content_type = "text/cloud-config"
-  #  content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
-  #  })
-  #}
 }

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -45,6 +45,7 @@ data "cloudinit_config" "artifactory" {
     content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/enable_license.tpl", {
       artifactory_license                        = local.artifactory_license
+      artifactory_access_token                   = local.artifactory_access_token
     })
   }
 

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -38,6 +38,7 @@ data "cloudinit_config" "artifactory" {
       db_username                                = local.db_username
       db_password                                = local.db_password
       artifactory_license                        = local.artifactory_license
+      artifactory_access_token                   = local.artifactory_access_token
     })
   }
 }

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -38,6 +38,7 @@ data "cloudinit_config" "artifactory" {
       db_fqdn                                    = local.db_fqdn
       db_username                                = local.db_username
       db_password                                = local.db_password
+      artifactory_license                        = local.artifactory_license
     })
   }
 

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -33,18 +33,18 @@ data "cloudinit_config" "artifactory" {
       ldap_group_settings_strategy               = local.ldap_group_settings_strategy
       ldap_group_settings_subtree                = local.ldap_group_settings_subtree
       http_proxy_host                            = ""
-      http_proxy_port                            = ""
-      artifactory_access_token                   = local.artifactory_access_token
+      http_proxy_port                            = "" 
       db_fqdn                                    = local.db_fqdn
       db_username                                = local.db_username
       db_password                                = local.db_password
       artifactory_license                        = local.artifactory_license
+      artifactory_access_token                   = local.artifactory_access_token
     })
   }
 
-  part {
-    content_type = "text/cloud-config"
-    content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
-    })
-  }
+  #part {
+  #  content_type = "text/cloud-config"
+  #  content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
+  #  })
+  #}
 }

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -45,6 +45,7 @@ data "cloudinit_config" "artifactory" {
   part {
     content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
+      artifactory_license                        = local.artifactory_license
     })
   }
 }

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -38,14 +38,7 @@ data "cloudinit_config" "artifactory" {
       db_fqdn                                    = local.db_fqdn
       db_username                                = local.db_username
       db_password                                = local.db_password
-    })
-  }
-
-  part {
-    content_type = "text/cloud-config"
-    content = templatefile("${path.module}/cloud-init/templates/enable_license.tpl", {
       artifactory_license                        = local.artifactory_license
-      artifactory_access_token                   = local.artifactory_access_token
     })
   }
 

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -45,7 +45,6 @@ data "cloudinit_config" "artifactory" {
   part {
     content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
-      artifactory_license                        = local.artifactory_license
     })
   }
 }

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -38,6 +38,12 @@ data "cloudinit_config" "artifactory" {
       db_fqdn                                    = local.db_fqdn
       db_username                                = local.db_username
       db_password                                = local.db_password
+    })
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-init/templates/enable_license.tpl", {
       artifactory_license                        = local.artifactory_license
     })
   }

--- a/groups/instance/locals.tf
+++ b/groups/instance/locals.tf
@@ -63,4 +63,6 @@ locals {
   ldap_group_settings_group_name_attribute   = local.secrets.ldap_group_settings_group_name_attribute
   ldap_group_settings_strategy               = local.secrets.ldap_group_settings_strategy
   ldap_group_settings_subtree                = local.secrets.ldap_group_settings_subtree
+
+  artifactory_license                        = local.secrets.artifactory_license
 }


### PR DESCRIPTION
Removed additional unnecessary cloud_init template file and refactored the run cmd within the same single template. The license key in vault required indentation to all lines par the first as when being consumed by TF & Cloud_init the indentation would be implemented incorrectly thus causing the artifactory service to fail completely.

Deployed last test instance. LDAP working as required from main login page and redirects straight to the dashboard as required. 