### PR TITLE
Change alb listener ssl policy

### DIFF
--- a/groups/instance/lb.tf
+++ b/groups/instance/lb.tf
@@ -84,7 +84,7 @@ resource "aws_lb_listener" "https" {
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = local.ssl_certificate_arn
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 
   default_action {
     type             = "forward"


### PR DESCRIPTION
Changing the ALB listener ssl policy to 'ELBSecurityPolicy-TLS13-1-2-2021-06' to implement a more secure suite of ciphers