### PR TITLE
Implement Default admin PW change

### DIFF
--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -763,9 +763,15 @@ write_files:
     content: |
       ${artifactory_license}
 
+  - path: /opt/jfrog/artifactory/var/etc/access/bootstrap.creds
+    permissions: '0600'
+    content: |
+      admin@*=${admin_password}
+
 runcmd:
   - systemctl enable artifactory
   - sudo mkdir /var/lib/artifactory
   - sudo mount -t efs -o tls ${efs_dns_name}:/ /var/lib/artifactory
   - sudo echo "${efs_dns_name}:/ /var/lib/artifactory efs defaults,_netdev,noresvport,tls 0 0" >> /etc/fstab
+  - sudo chown artifactory:artifactory /opt/jfrog/artifactory/var/etc/access/bootstrap.creds
   - systemctl restart artifactory

--- a/groups/instance/cloud_init.tf
+++ b/groups/instance/cloud_init.tf
@@ -32,6 +32,7 @@ data "cloudinit_config" "artifactory" {
       artifactory_license                        = local.artifactory_license
       artifactory_access_token                   = local.artifactory_access_token
       efs_dns_name                               = aws_efs_file_system.efs_file_system.dns_name
+      admin_password                             = local.admin_password
     })
   }
 }

--- a/groups/instance/locals.tf
+++ b/groups/instance/locals.tf
@@ -62,4 +62,6 @@ locals {
   ldap_group_settings_subtree                = local.secrets.ldap_group_settings_subtree
 
   artifactory_license                        = local.secrets.artifactory_license
+
+  admin_password                             = local.secrets.admin_password
 }


### PR DESCRIPTION
Bootstrap creds file created via cloud_init template. New Admin password stored in Vault.
On initial deployment of a new instance the bootstrap file is consumed as required. 
Default password is confirmed to have been changed to what is being stored in vault