### PR TITLE
Feature/dvop 2685

### DIFF
--- a/groups/instance/cloud-init/templates/enable_config.tpl
+++ b/groups/instance/cloud-init/templates/enable_config.tpl
@@ -749,7 +749,6 @@ write_files:
 
 runcmd:
   - systemctl enable artifactory
-  - sudo mkdir /var/lib/artifactory/
   - sudo mount -t efs -o tls ${efs_dns_name}:/ /var/lib/artifactory
   - sudo echo "${efs_dns_name}:/ /var/lib/artifactory efs defaults,_netdev,noresvport,tls 0 0" >> /etc/fstab
   - sudo chown artifactory:artifactory /opt/jfrog/artifactory/var/etc/access/bootstrap.creds

--- a/groups/instance/data.tf
+++ b/groups/instance/data.tf
@@ -73,9 +73,8 @@ data "aws_route53_zone" "selected" {
 data "aws_ami" "artifactory_ami" {
   most_recent = true
   owners      = [local.ami_owner_id]
-  #name_regex  = "${var.service}-${var.default_ami_version_pattern}"
-  name_regex  = "artifactory-feature"
-
+  name_regex  = "${var.service}-${var.default_ami_version_pattern}"
+  
   filter {
     name   = "name"
     values = ["${var.service}-*"]

--- a/groups/instance/data.tf
+++ b/groups/instance/data.tf
@@ -73,7 +73,8 @@ data "aws_route53_zone" "selected" {
 data "aws_ami" "artifactory_ami" {
   most_recent = true
   owners      = [local.ami_owner_id]
-  name_regex  = "${var.service}-${var.default_ami_version_pattern}"
+  #name_regex  = "${var.service}-${var.default_ami_version_pattern}"
+  name_regex  = "artifactory-feature"
 
   filter {
     name   = "name"


### PR DESCRIPTION
Removing the creation of the EFS directory as this is now being implemented via the build of an AMI.

Working as required, EFS continues to mount. Service starts as required. 

[DVOP-2685](https://companieshouse.atlassian.net/browse/DVOP-2685)

[DVOP-2685]: https://companieshouse.atlassian.net/browse/DVOP-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ