### PR TITLE
Update cloudwatch logs config

### DIFF
--- a/groups/instance/cloudwatch.tf
+++ b/groups/instance/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_group" "artifactory" {
   name              = local.resource_prefix
   retention_in_days = var.cloudwatch_log_group_retention_in_days
-  kms_key_id        = aws_kms_key.artifactory.key_id
+  kms_key_id        = aws_kms_key.artifactory.arn
 
   tags = {
     Name = local.resource_prefix

--- a/groups/instance/kms.tf
+++ b/groups/instance/kms.tf
@@ -95,4 +95,32 @@ data "aws_iam_policy_document" "kms_key_asg_access" {
       values   = ["true"]
     }
   }
+
+  statement {
+    sid    = "Allow Cloudwatch Logs access for encrypted logs"
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.${var.region}.amazonaws.com"
+      ]
+    }
+
+    resources = ["*"]
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values   = ["arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:${local.resource_prefix}"]
+    }
+  }
 }

--- a/groups/instance/main.tf
+++ b/groups/instance/main.tf
@@ -48,7 +48,4 @@ module "efs_file_system" {
       root_directory = "/${var.efs_artifacts_access_point_name}"
     }
   }
-  depends_on = [
-    aws_kms_key.artifactory
-  ]
 }


### PR DESCRIPTION
Fixes input argument value on `aws_cloudwatch_log_group` resource
Updated KMS key policy to permit access from the CloudWatch Logs service
 - Allows for the encryption and decryption of log messages within the log group