### PR TITLE
Update CloudWatch Agent Logs Configuration

### DIFF
--- a/groups/instance/cloud-init/templates/cloudwatch-agent.tpl
+++ b/groups/instance/cloud-init/templates/cloudwatch-agent.tpl
@@ -6,12 +6,14 @@ write_files:
       {
         "agent": {
           "metrics_collection_interval": 60,
-          "run_as_user": "cwagent"
+          "run_as_user": "artifactory"
         },
 %{ if cloudwatch_log_collection_enabled ~}
         "logs": {
-          "logs_collected": {
-            "collect_list": ${cloudwatch_collect_list_json}
+          "files": {
+            "logs_collected": {
+              "collect_list": ${cloudwatch_collect_list_json}
+            }
           }
         },
 %{ endif ~}

--- a/groups/instance/cloud-init/templates/cloudwatch-agent.tpl
+++ b/groups/instance/cloud-init/templates/cloudwatch-agent.tpl
@@ -10,8 +10,8 @@ write_files:
         },
 %{ if cloudwatch_log_collection_enabled ~}
         "logs": {
-          "files": {
-            "logs_collected": {
+          "logs_collected": {
+            "files": {
               "collect_list": ${cloudwatch_collect_list_json}
             }
           }

--- a/groups/instance/cloud-init/templates/cloudwatch-agent.tpl
+++ b/groups/instance/cloud-init/templates/cloudwatch-agent.tpl
@@ -12,8 +12,8 @@ write_files:
         "logs": {
           "logs_collected": {
             "collect_list": ${cloudwatch_collect_list_json}
-          },
-        }
+          }
+        },
 %{ endif ~}
         "metrics": {
           "aggregation_dimensions": [

--- a/groups/instance/profiles/shared-services-eu-west-2/platform/vars
+++ b/groups/instance/profiles/shared-services-eu-west-2/platform/vars
@@ -1,3 +1,12 @@
 account_name = "shared-services"
 environment  = "platform"
 region       = "eu-west-2"
+
+cloudwatch_logs_collected = [
+  {
+    name = "artifactory-service.log"
+  },
+  {
+    name = "artifactory-request-out.log"
+  }
+]

--- a/groups/instance/variables.tf
+++ b/groups/instance/variables.tf
@@ -219,7 +219,7 @@ variable "cloudwatch_logs_collected" {
   type        = list(object(
     {
       name             = string
-      timestamp_format = optional(string, "%Y-%m-%dT%H:%M:%S.000Z")
+      timestamp_format = optional(string, "%Y-%m-%dT%H:%M:%S.%f")
     }
   ))
 }


### PR DESCRIPTION
Updated `timestamp_format` string to correctly parse the RFC3339-style timestamps used by JFrog
Sets cloudwatch agent to run as the `artifactory` user to resolve logfile access issues
Add a missing configuraiton block to the agent template
Adds initial logfiles to capture to profile vars