### PR TITLE
Fix permissions on bootstrap.creds file

### DIFF
--- a/groups/instance/cloud-init/templates/admin_pw.tpl
+++ b/groups/instance/cloud-init/templates/admin_pw.tpl
@@ -7,5 +7,5 @@ write_files:
       cat <<EOF > ${artifactory_base_path}/var/etc/access/bootstrap.creds
       admin@*=$${AWSCLI_COMMAND}
       EOF
-      chmod 0640 ${artifactory_base_path}/var/etc/access/bootstrap.creds
+      chmod 0600 ${artifactory_base_path}/var/etc/access/bootstrap.creds
       chown ${artifactory_user}:${artifactory_group} ${artifactory_base_path}/var/etc/access/bootstrap.creds


### PR DESCRIPTION
Re-set file mode on `bootstrap.creds` back to what it should be.